### PR TITLE
Update documentation to use quotes in YAML examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode-version: [10.3, 11, 11.2, 11.4.0, 11.4.1, ^11.4.0, latest, latest-stable]
+        xcode-version: ['10.3', '11', '11.2', '11.4.0', '11.4.1', '^11.4.0', latest, latest-stable]
       fail-fast: false
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ The list of all available versions can be found in [virtual-environments](https:
 # Available parameters
 | Argument                | Description              | Format    |
 |-------------------------|--------------------------|--------------------|
-| `xcode-version`           | Specify the Xcode version to use | `latest`, `latest-stable` or any [semver](https://semver.org/) string  |
+| `xcode-version`           | Specify the Xcode version to use | - `latest`<br> - `latest-stable`<br> - Any [SemVer](https://semver.org/) string |
 
-**Examples:** `latest`, `latest-stable`, `10`, `11.4`, `11.4.0`, `^11.4.0`  
-**Note:**
+**Notes:**
 - `latest-stable` points to the latest stable version of Xcode
-- `latest` *includes* beta releases that GitHub actions has installed.
+- `latest` *includes* beta releases that GitHub actions has installed
+- SemVer examples: `10`, `11.4`, `12.0`, `11.7.0`, `^11.7.0` (find more examples in [SemVer cheatsheet](https://devhints.io/semver))
+- If sets specific version, wraps it to single quotes in YAML like `'12.0'` to pass it as string because GitHub trimmes trailing `.0` from numbers
 
 # Usage
 Set the latest stable Xcode version:
@@ -44,7 +45,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.1
       with:
-        xcode-version: 11.4
+        xcode-version: '12.0'
 ```
 # License
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ The list of all available versions can be found in [virtual-environments](https:
 # Available parameters
 | Argument                | Description              | Format    |
 |-------------------------|--------------------------|--------------------|
-| `xcode-version`           | Specify the Xcode version to use | - `latest`<br> - `latest-stable`<br> - Any [SemVer](https://semver.org/) string |
+| `xcode-version`           | Specify the Xcode version to use | - `latest` or<br> - `latest-stable` or<br> - [SemVer](https://semver.org/) string |
 
 **Notes:**
 - `latest-stable` points to the latest stable version of Xcode
 - `latest` *includes* beta releases that GitHub actions has installed
 - SemVer examples: `10`, `11.4`, `12.0`, `11.7.0`, `^11.7.0` (find more examples in [SemVer cheatsheet](https://devhints.io/semver))
-- If sets specific version, wraps it to single quotes in YAML like `'12.0'` to pass it as string because GitHub trimmes trailing `.0` from numbers
+- If sets a specific version, wraps it to single quotes in YAML like `'12.0'` to pass it as string because GitHub trimmes trailing `.0` from numbers
 
 # Usage
 Set the latest stable Xcode version:


### PR DESCRIPTION
Recently, we have faced with an issue: GitHub interprets YAML `xcode-version: 12.0` as  `xcode-version: 12` and trim trailing `.0`.
It is better approach to use quotes in YAML to make sure that value will be interpreted as string and prevent such issues.