### PR TITLE
Improve action output - print Xcode BuildNumber

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -51,9 +51,9 @@ const run = () => {
                 ...selector.getAllVersions().map(ver => `- ${ver.version} (${ver.path})`)
             ].join(os_1.EOL));
         }
-        core.debug(`Xcode ${targetVersion.version} (${targetVersion.path}) will be set`);
+        core.debug(`Xcode ${targetVersion.version} (${targetVersion.buildNumber}) (${targetVersion.path}) will be set`);
         selector.setVersion(targetVersion);
-        core.info(`Xcode is set to '${targetVersion.version}'`);
+        core.info(`Xcode is set to '${targetVersion.version}' (${targetVersion.buildNumber})`);
     }
     catch (error) {
         core.setFailed(error.message);

--- a/dist/index.js
+++ b/dist/index.js
@@ -53,7 +53,7 @@ const run = () => {
         }
         core.debug(`Xcode ${targetVersion.version} (${targetVersion.buildNumber}) (${targetVersion.path}) will be set`);
         selector.setVersion(targetVersion);
-        core.info(`Xcode is set to '${targetVersion.version}' (${targetVersion.buildNumber})`);
+        core.info(`Xcode is set to ${targetVersion.version} (${targetVersion.buildNumber})`);
     }
     catch (error) {
         core.setFailed(error.message);

--- a/src/setup-xcode.ts
+++ b/src/setup-xcode.ts
@@ -31,7 +31,7 @@ const run = (): void => {
 
         core.debug(`Xcode ${targetVersion.version} (${targetVersion.buildNumber}) (${targetVersion.path}) will be set`);
         selector.setVersion(targetVersion);
-        core.info(`Xcode is set to '${targetVersion.version}' (${targetVersion.buildNumber})`);
+        core.info(`Xcode is set to ${targetVersion.version} (${targetVersion.buildNumber})`);
     } catch (error) {
         core.setFailed(error.message);
     }

--- a/src/setup-xcode.ts
+++ b/src/setup-xcode.ts
@@ -29,9 +29,9 @@ const run = (): void => {
             );
         }
 
-        core.debug(`Xcode ${targetVersion.version} (${targetVersion.path}) will be set`);
+        core.debug(`Xcode ${targetVersion.version} (${targetVersion.buildNumber}) (${targetVersion.path}) will be set`);
         selector.setVersion(targetVersion);
-        core.info(`Xcode is set to '${targetVersion.version}'`);
+        core.info(`Xcode is set to '${targetVersion.version}' (${targetVersion.buildNumber})`);
     } catch (error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
It makes sense to print Xcode buildNumber to action output. It can be pretty useful for beta versions.
For example, Xcode 12.2 beta prints output `12.2.0` and it is pretty unclear what the number of that beta. If we print buildNumber `12B5035g`, it would be useful


