### PR TITLE
Allow Xcode paths with different patterns

### DIFF
--- a/__tests__/xcode-utils.test.ts
+++ b/__tests__/xcode-utils.test.ts
@@ -22,6 +22,7 @@ const buildFsDirentItem = (name: string, opt: { isSymbolicLink: boolean; isDirec
 const fakeReadDirResults = [
     buildFsDirentItem("Xcode_2.app", { isSymbolicLink: true, isDirectory: false }),
     buildFsDirentItem("Xcode.app", { isSymbolicLink: false, isDirectory: true }),
+    buildFsDirentItem("Xcode12.4.app", { isSymbolicLink: false, isDirectory: true }),
     buildFsDirentItem("Xcode_11.1.app", { isSymbolicLink: false, isDirectory: true }),
     buildFsDirentItem("Xcode_11.1_beta.app", { isSymbolicLink: true, isDirectory: false }),
     buildFsDirentItem("Xcode_11.2.1.app", { isSymbolicLink: false, isDirectory: true }),
@@ -40,6 +41,8 @@ describe("getInstalledXcodeApps", () => {
     it("versions are filtered correctly", () => {
         readdirSyncSpy.mockImplementation(() => fakeReadDirResults);
         const expectedVersions: string[] = [
+            "/Applications/Xcode.app",
+            "/Applications/Xcode12.4.app",
             "/Applications/Xcode_11.1.app",
             "/Applications/Xcode_11.2.1.app",
             "/Applications/Xcode_11.4_beta.app",

--- a/src/xcode-utils.ts
+++ b/src/xcode-utils.ts
@@ -26,7 +26,7 @@ export const parsePlistFile = (plistPath: string): plist.PlistObject | null => {
 
 export const getInstalledXcodeApps = (): string[] => {
     const applicationsDirectory = "/Applications";
-    const xcodeAppFilenameRegex = /Xcode_([\d.]+)(_beta)?\.app/;
+    const xcodeAppFilenameRegex = /^Xcode.*\.app$/;
 
     const allApplicationsChildItems = fs.readdirSync(applicationsDirectory, { encoding: "utf8", withFileTypes: true });
     const allApplicationsRealItems = allApplicationsChildItems.filter(child => !child.isSymbolicLink() && child.isDirectory());


### PR DESCRIPTION
Resolves https://github.com/maxim-lobanov/setup-xcode/issues/17

Improved existing regex to make it more liberal and allow the following patterns:
- `/Application/Xcode12.4.app`
- `/Application/Xcode.app`