### PR TITLE
Improve available versions output if version is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The list of all available versions can be found in [virtual-environments](https:
 # Available parameters
 | Argument                | Description              | Format    |
 |-------------------------|--------------------------|--------------------|
-| `xcode-version`           | Specify the Xcode version to use | - `latest` or<br> - `latest-stable` or<br> - [SemVer](https://semver.org/) string or<br> - [SemVer](https://semver.org/)`-beta` |
+| `xcode-version`           | Specify the Xcode version to use | - `latest` or<br> - `latest-stable` or<br> - [SemVer](https://semver.org/) string or<br> - `<semver>-beta` |
 
 **Notes:**
 - `latest-stable` points to the latest stable version of Xcode
@@ -43,22 +43,22 @@ Set the specific stable version of Xcode:
 ```
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '12.0'
+        xcode-version: '13.0'
 ```
 
 Set the specific beta version of Xcode:
 ```
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '12.0-beta'
+        xcode-version: '13.0-beta'
 ```
 # License
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/dist/index.js
+++ b/dist/index.js
@@ -29,7 +29,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__webpack_require__(2186));
 const xcode_selector_1 = __webpack_require__(8865);
-const os_1 = __webpack_require__(2087);
 const run = () => {
     try {
         if (process.platform !== "darwin") {
@@ -45,11 +44,9 @@ const run = () => {
         }
         const targetVersion = selector.findVersion(versionSpec);
         if (!targetVersion) {
-            throw new Error([
-                `Could not find Xcode version that satisfied version spec: '${versionSpec}'`,
-                "Available versions:",
-                ...selector.getAllVersions().map(ver => `- ${ver.version} (${ver.path})`),
-            ].join(os_1.EOL));
+            console.log("Available versions:");
+            console.table(selector.getAllVersions());
+            throw new Error(`Could not find Xcode version that satisfied version spec: '${versionSpec}'`);
         }
         core.debug(`Xcode ${targetVersion.version} (${targetVersion.buildNumber}) (${targetVersion.path}) will be set`);
         selector.setVersion(targetVersion);

--- a/src/setup-xcode.ts
+++ b/src/setup-xcode.ts
@@ -1,6 +1,5 @@
 import * as core from "@actions/core";
 import { XcodeSelector } from "./xcode-selector";
-import { EOL } from "os";
 
 const run = (): void => {
     try {
@@ -22,12 +21,10 @@ const run = (): void => {
         const targetVersion = selector.findVersion(versionSpec);
 
         if (!targetVersion) {
+            console.log("Available versions:");
+            console.table(selector.getAllVersions());
             throw new Error(
-                [
-                    `Could not find Xcode version that satisfied version spec: '${versionSpec}'`,
-                    "Available versions:",
-                    ...selector.getAllVersions().map(ver => `- ${ver.version} (${ver.path})`),
-                ].join(EOL)
+                `Could not find Xcode version that satisfied version spec: '${versionSpec}'`
             );
         }
 


### PR DESCRIPTION
Small improvement of action output in case of any issues. Print more information about available Xcode versions including their build number and release type:
![image](https://user-images.githubusercontent.com/16715858/136359759-5391a1ea-0ce7-4b50-9ff2-0e817180fd62.png)
