### PR TITLE
Update action runtime to node24 and polish e2e test matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,35 +11,24 @@ permissions:
   contents: read
 
 jobs:
-  versions-macOS-15:
-    name: macOS 15
-    runs-on: macos-15
+  versions:
+    name: ${{ matrix.runner }} / ${{ matrix.xcode-version }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#xcode
-        xcode-version: ['16.2', '16.4', latest, latest-stable]
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: ./
-        name: Setup Xcode
-        id: setup-xcode
-        with:
-          xcode-version: ${{ matrix.xcode-version }}
-      - name: Print output variables
-        run: |
-          echo "Version: ${{ steps.setup-xcode.outputs.version }}"
-          echo "Path: ${{ steps.setup-xcode.outputs.path }}"
-
-  versions-macOS-26:
-    name: macOS 26
-    runs-on: macos-26
-    strategy:
-      matrix:
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md#xcode
-        xcode-version: ['26.2', '26.3', latest, latest-stable]
+        runner: [macos-15, macos-26]
+        xcode-version: [latest, latest-stable]
+        include:
+          # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#xcode
+          - runner: macos-15
+            xcode-version: '16.2'
+          - runner: macos-15
+            xcode-version: '16.4'
+          # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md#xcode
+          - runner: macos-26
+            xcode-version: '26.2'
+          - runner: macos-26
+            xcode-version: '26.3'
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,56 +7,39 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+permissions:
+  contents: read
+
 jobs:
-  versions-macOS-12:
-    name: macOS 12
-    runs-on: macos-12
+  versions-macOS-15:
+    name: macOS 15
+    runs-on: macos-15
     strategy:
       matrix:
-        xcode-version: ['13.2.1', '13.4', '14.0.1', '14', '14.2', latest, latest-stable]
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#xcode
+        xcode-version: ['16.2', '16.4', latest, latest-stable]
       fail-fast: false
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - uses: ./
-      name: Setup Xcode
-      id: setup-xcode
-      with:
-        xcode-version: ${{ matrix.xcode-version }}
-    - name: Print output variables
-      run: |
-        echo "Version: ${{ steps.setup-xcode.outputs.version }}"
-        echo "Path: ${{ steps.setup-xcode.outputs.path }}"
+      - uses: ./
+        name: Setup Xcode
+        id: setup-xcode
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
+      - name: Print output variables
+        run: |
+          echo "Version: ${{ steps.setup-xcode.outputs.version }}"
+          echo "Path: ${{ steps.setup-xcode.outputs.path }}"
 
-  versions-macOS-13:
-    name: macOS 13
-    runs-on: macos-13
+  versions-macOS-26:
+    name: macOS 26
+    runs-on: macos-26
     strategy:
       matrix:
-        xcode-version: ['14', '14.2', '14.3.1', latest, latest-stable]
-      fail-fast: false
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - uses: ./
-      name: Setup Xcode
-      id: setup-xcode
-      with:
-        xcode-version: ${{ matrix.xcode-version }}
-    - name: Print output variables
-      run: |
-        echo "Version: ${{ steps.setup-xcode.outputs.version }}"
-        echo "Path: ${{ steps.setup-xcode.outputs.path }}"
-
-  versions-macOS-14:
-    name: macOS 14
-    runs-on: macos-14
-    strategy:
-      matrix:
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
-        xcode-version: ['14.3.1', '15.2', '15.3', latest, latest-stable]
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md#xcode
+        xcode-version: ['26.2', '26.3', latest, latest-stable]
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set Node.JS
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 24.x
 
     - name: npm install
       run: npm install

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: latest
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'code'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.5",
-        "@types/node": "^20.6.3",
+        "@types/node": "^24.0.0",
         "@types/plist": "^3.0.2",
         "@types/semver": "^7.5.2",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
@@ -1285,10 +1285,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.3.tgz",
-      "integrity": "sha512-HksnYH4Ljr4VQgEy2lTStbCKv/P590tmPe5HqOnv9Gprffgv5WXAY+Y5Gqniu0GGqeTCUdBnzC3QSrzPkBkAMA==",
-      "dev": true
+      "version": "24.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/plist": {
       "version": "3.0.2",
@@ -5009,6 +5013,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6154,10 +6165,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.3.tgz",
-      "integrity": "sha512-HksnYH4Ljr4VQgEy2lTStbCKv/P590tmPe5HqOnv9Gprffgv5WXAY+Y5Gqniu0GGqeTCUdBnzC3QSrzPkBkAMA==",
-      "dev": true
+      "version": "24.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~7.16.0"
+      }
     },
     "@types/plist": {
       "version": "3.0.2",
@@ -8765,6 +8779,12 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",
-    "@types/node": "^20.6.3",
+    "@types/node": "^24.0.0",
     "@types/plist": "^3.0.2",
     "@types/semver": "^7.5.2",
     "@typescript-eslint/eslint-plugin": "^6.7.2",


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Closes #99.